### PR TITLE
Disable reqwest default features to use only rustls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ homepage = "https://infisical.com"
 include = ["**/*.rs", "Cargo.toml"]
 
 [dependencies]
-reqwest = { version = "0.12", features = ['json', 'blocking', 'rustls-tls'] }
+reqwest = { version = "0.12", features = ['json', 'blocking', 'rustls-tls', 'http2'], default-features = false }
 tokio = { version = "1.46", features = ["full"] }
 serde = { version = "1", features = ['derive'] }
 serde_json = "1"

--- a/src/client/mod.rs
+++ b/src/client/mod.rs
@@ -158,12 +158,12 @@ impl Client {
     }
 
     /// Access secrets operations.
-    pub fn secrets(&self) -> SecretsClient {
+    pub fn secrets(&self) -> SecretsClient<'_> {
         SecretsClient::new(self)
     }
 
     /// Access KMS operations.
-    pub fn kms(&self) -> KmsClient {
+    pub fn kms(&self) -> KmsClient<'_> {
         KmsClient::new(self)
     }
 }


### PR DESCRIPTION
Reqwest depends on openssl (on linux) by default. This package already specifies rustls-tls but does not disable the default features. From https://docs.rs/reqwest/0.12.23/reqwest/index.html :

default-tls (enabled by default): Provides TLS support to connect over HTTPS.

This is required to allow building on a static musl target, otherwise openssl-sys complains it cannot find openssl library.

# Description 📣

Before this PR, `cargo check --target x86_64-unknown-linux-musl` fails on openssl-sys crate with "Could not find directory os OpenSSL installation".

Disabling reqwest default features fixes this by using rustls properly.

---

- [] All tests pass with `make test` : I don't want to setup an infisical instance just to pass these tests, two tests fail because I didn't set INFISICAL_CLIENT_ID 
- [ ] I ensured the PR is ready for review with `make reviewable` : Complaining about lifetime elision in the current main branch. Fixed it and it fails on tests again.
- [X] I have read and acknowledged the [code of conduct](https://infisical.com/docs/contributing/getting-started/code-of-conduct)
